### PR TITLE
Close #1334 (#1679)

### DIFF
--- a/RetailCoder.VBE/UI/Command/FindAllImplementationsCommand.cs
+++ b/RetailCoder.VBE/UI/Command/FindAllImplementationsCommand.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
@@ -9,6 +8,7 @@ using Rubberduck.Common;
 using Rubberduck.Parsing.Grammar;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
+using Rubberduck.UI.Command.MenuItems;
 using Rubberduck.UI.Controls;
 
 namespace Rubberduck.UI.Command
@@ -17,7 +17,7 @@ namespace Rubberduck.UI.Command
     /// A command that finds all implementations of a specified method, or of the active interface module.
     /// </summary>
     [ComVisible(false)]
-    public class FindAllImplementationsCommand : CommandBase
+    public class FindAllImplementationsCommand : CommandBase, IDisposable
     {
         private readonly INavigateCommand _navigateCommand;
         private readonly IMessageBox _messageBox;
@@ -26,7 +26,9 @@ namespace Rubberduck.UI.Command
         private readonly SearchResultPresenterInstanceManager _presenterService;
         private readonly VBE _vbe;
 
-        public FindAllImplementationsCommand(INavigateCommand navigateCommand, IMessageBox messageBox, RubberduckParserState state, VBE vbe, ISearchResultsWindowViewModel viewModel, SearchResultPresenterInstanceManager presenterService)
+        public FindAllImplementationsCommand(INavigateCommand navigateCommand, IMessageBox messageBox,
+            RubberduckParserState state, VBE vbe, ISearchResultsWindowViewModel viewModel,
+            SearchResultPresenterInstanceManager presenterService)
         {
             _navigateCommand = navigateCommand;
             _messageBox = messageBox;
@@ -34,6 +36,54 @@ namespace Rubberduck.UI.Command
             _vbe = vbe;
             _viewModel = viewModel;
             _presenterService = presenterService;
+
+            _state.StateChanged += _state_StateChanged;
+        }
+
+        private Declaration FindNewDeclaration(Declaration declaration)
+        {
+            return _state.AllUserDeclarations.SingleOrDefault(item =>
+                        item.ProjectId == declaration.ProjectId &&
+                        item.ComponentName == declaration.ComponentName &&
+                        item.ParentScope == declaration.ParentScope &&
+                        item.IdentifierName == declaration.IdentifierName &&
+                        item.DeclarationType == declaration.DeclarationType);
+        }
+
+        private void _state_StateChanged(object sender, ParserStateEventArgs e)
+        {
+            if (e.State != ParserState.Ready) { return; }
+
+            if (_viewModel == null) { return; }
+
+            UiDispatcher.InvokeAsync(UpdateTab);
+        }
+
+        private void UpdateTab()
+        {
+            var findImplementationsTabs = _viewModel.Tabs.Where(
+                t => t.Header.StartsWith(RubberduckUI.AllImplementations_Caption.Replace("'{0}'", ""))).ToList();
+
+            foreach (var tab in findImplementationsTabs)
+            {
+                var newTarget = FindNewDeclaration(tab.Target);
+                if (newTarget == null)
+                {
+                    tab.CloseCommand.Execute(null);
+                    return;
+                }
+
+                var vm = CreateViewModel(newTarget);
+                if (vm.SearchResults.Any())
+                {
+                    tab.SearchResults = vm.SearchResults;
+                    tab.Target = vm.Target;
+                }
+                else
+                {
+                    tab.CloseCommand.Execute(null);
+                }
+            }
         }
 
         public override bool CanExecute(object parameter)
@@ -169,6 +219,14 @@ namespace Rubberduck.UI.Command
             name = member.ComponentName + "." + member.IdentifierName;
             return items.FindInterfaceImplementationMembers(member.IdentifierName)
                    .Where(item => item.IdentifierName == member.ComponentName + "_" + member.IdentifierName);
+        }
+
+        public void Dispose()
+        {
+            if (_state != null)
+            {
+                _state.StateChanged += _state_StateChanged;
+            }
         }
     }
 }

--- a/RetailCoder.VBE/UI/Command/FindAllReferencesCommand.cs
+++ b/RetailCoder.VBE/UI/Command/FindAllReferencesCommand.cs
@@ -1,11 +1,11 @@
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using Microsoft.Vbe.Interop;
 using Rubberduck.Parsing.Symbols;
 using Rubberduck.Parsing.VBA;
+using Rubberduck.UI.Command.MenuItems;
 using Rubberduck.UI.Controls;
 
 namespace Rubberduck.UI.Command
@@ -14,7 +14,7 @@ namespace Rubberduck.UI.Command
     /// A command that locates all references to a specified identifier, or of the active code module.
     /// </summary>
     [ComVisible(false)]
-    public class FindAllReferencesCommand : CommandBase
+    public class FindAllReferencesCommand : CommandBase, IDisposable
     {
         private readonly INavigateCommand _navigateCommand;
         private readonly IMessageBox _messageBox;
@@ -23,7 +23,9 @@ namespace Rubberduck.UI.Command
         private readonly SearchResultPresenterInstanceManager _presenterService;
         private readonly VBE _vbe;
 
-        public FindAllReferencesCommand(INavigateCommand navigateCommand, IMessageBox messageBox, RubberduckParserState state, VBE vbe, ISearchResultsWindowViewModel viewModel, SearchResultPresenterInstanceManager presenterService)
+        public FindAllReferencesCommand(INavigateCommand navigateCommand, IMessageBox messageBox,
+            RubberduckParserState state, VBE vbe, ISearchResultsWindowViewModel viewModel,
+            SearchResultPresenterInstanceManager presenterService)
         {
             _navigateCommand = navigateCommand;
             _messageBox = messageBox;
@@ -31,6 +33,54 @@ namespace Rubberduck.UI.Command
             _vbe = vbe;
             _viewModel = viewModel;
             _presenterService = presenterService;
+
+            _state.StateChanged += _state_StateChanged;
+        }
+
+        private Declaration FindNewDeclaration(Declaration declaration)
+        {
+            return _state.AllUserDeclarations.SingleOrDefault(item =>
+                        item.ProjectId == declaration.ProjectId && 
+                        item.ComponentName == declaration.ComponentName &&
+                        item.ParentScope == declaration.ParentScope &&
+                        item.IdentifierName == declaration.IdentifierName && 
+                        item.DeclarationType == declaration.DeclarationType);
+        }
+
+        private void _state_StateChanged(object sender, ParserStateEventArgs e)
+        {
+            if (e.State != ParserState.Ready) { return; }
+
+            if (_viewModel == null) { return; }
+
+            UiDispatcher.InvokeAsync(UpdateTab);
+        }
+
+        private void UpdateTab()
+        {
+            var findReferenceTabs = _viewModel.Tabs.Where(
+                t => t.Header.StartsWith(RubberduckUI.AllReferences_Caption.Replace("'{0}'", ""))).ToList();
+
+            foreach (var tab in findReferenceTabs)
+            {
+                var newTarget = FindNewDeclaration(tab.Target);
+                if (newTarget == null)
+                {
+                    tab.CloseCommand.Execute(null);
+                    return;
+                }
+
+                var vm = CreateViewModel(newTarget);
+                if (vm.SearchResults.Any())
+                {
+                    tab.SearchResults = vm.SearchResults;
+                    tab.Target = vm.Target;
+                }
+                else
+                {
+                    tab.CloseCommand.Execute(null);
+                }
+            }
         }
 
         public override bool CanExecute(object parameter)
@@ -109,6 +159,14 @@ namespace Rubberduck.UI.Command
             }
 
             return _state.FindSelectedDeclaration(_vbe.ActiveCodePane);
+        }
+
+        public void Dispose()
+        {
+            if (_state != null)
+            {
+                _state.StateChanged += _state_StateChanged;
+            }
         }
     }
 }

--- a/RetailCoder.VBE/UI/Command/ShowParserErrorsCommand.cs
+++ b/RetailCoder.VBE/UI/Command/ShowParserErrorsCommand.cs
@@ -17,15 +17,13 @@ namespace Rubberduck.UI.Command
     [ComVisible(false)]
     public class ShowParserErrorsCommand : CommandBase, IShowParserErrorsCommand
     {
-        private readonly VBE _vbe;
         private readonly INavigateCommand _navigateCommand;
         private readonly RubberduckParserState _state;
         private readonly ISearchResultsWindowViewModel _viewModel;
         private readonly SearchResultPresenterInstanceManager _presenterService;
 
-        public ShowParserErrorsCommand(VBE vbe, INavigateCommand navigateCommand, RubberduckParserState state, ISearchResultsWindowViewModel viewModel, SearchResultPresenterInstanceManager presenterService)
+        public ShowParserErrorsCommand(INavigateCommand navigateCommand, RubberduckParserState state, ISearchResultsWindowViewModel viewModel, SearchResultPresenterInstanceManager presenterService)
         {
-            _vbe = vbe;
             _navigateCommand = navigateCommand;
             _state = state;
             _viewModel = viewModel;
@@ -50,17 +48,24 @@ namespace Rubberduck.UI.Command
                 return;
             }
 
-            var oldTab = _viewModel.Tabs.FirstOrDefault(tab => tab.Header == RubberduckUI.Parser_ParserError);
-            if (_state.Status == ParserState.Error)
-            {
-                var viewModel = CreateViewModel();
-                _viewModel.AddTab(viewModel);
-                _viewModel.SelectedTab = viewModel;
-            }
+            var vm = CreateViewModel();
 
-            if (oldTab != null)
+            var tab = _viewModel.Tabs.FirstOrDefault(t => t.Header == RubberduckUI.Parser_ParserError);
+            if (tab != null)
             {
-                oldTab.CloseCommand.Execute(null);
+                if (_state.Status != ParserState.Error)
+                {
+                    tab.CloseCommand.Execute(null);
+                }
+                else
+                {
+                    tab.SearchResults = vm.SearchResults;
+                }
+            }
+            else if (_state.Status == ParserState.Error)
+            {
+                _viewModel.AddTab(vm);
+                _viewModel.SelectedTab = vm;
             }
         }
 

--- a/RetailCoder.VBE/UI/Controls/ISearchResultsWindowViewModel.cs
+++ b/RetailCoder.VBE/UI/Controls/ISearchResultsWindowViewModel.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Rubberduck.UI.Controls
 {
@@ -7,7 +7,7 @@ namespace Rubberduck.UI.Controls
     {
         void AddTab(SearchResultsViewModel viewModel);
         event EventHandler LastTabClosed;
-        IEnumerable<SearchResultsViewModel> Tabs { get; }
+        ObservableCollection<SearchResultsViewModel> Tabs { get; }
         SearchResultsViewModel SelectedTab { get; set; }
     }
 }

--- a/RetailCoder.VBE/UI/Controls/SearchResultsViewModel.cs
+++ b/RetailCoder.VBE/UI/Controls/SearchResultsViewModel.cs
@@ -13,35 +13,46 @@ namespace Rubberduck.UI.Controls
     {
         private readonly INavigateCommand _navigateCommand;
         private readonly string _header;
-        private readonly Declaration _target;
 
         public SearchResultsViewModel(INavigateCommand navigateCommand, string header, Declaration target, IEnumerable<SearchResultItem> searchResults)
         {
             _navigateCommand = navigateCommand;
             _header = header;
-            _target = target;
-            _searchResults = new ObservableCollection<SearchResultItem>(searchResults);
-            _searchResultsSource = new CollectionViewSource();
-            _searchResultsSource.Source = _searchResults;
-            _searchResultsSource.GroupDescriptions.Add(new PropertyGroupDescription("ParentScope.QualifiedName.QualifiedModuleName.Name"));
-            _searchResultsSource.SortDescriptions.Add(new SortDescription("ParentScope.QualifiedName.QualifiedModuleName.Name", ListSortDirection.Ascending));
-            _searchResultsSource.SortDescriptions.Add(new SortDescription("Selection.StartLine", ListSortDirection.Ascending));
-            _searchResultsSource.SortDescriptions.Add(new SortDescription("Selection.StartColumn", ListSortDirection.Ascending));
+            Target = target;
+            SearchResultsSource = new CollectionViewSource();
+            SearchResultsSource.GroupDescriptions.Add(new PropertyGroupDescription("ParentScope.QualifiedName.QualifiedModuleName.Name"));
+            SearchResultsSource.SortDescriptions.Add(new SortDescription("ParentScope.QualifiedName.QualifiedModuleName.Name", ListSortDirection.Ascending));
+            SearchResultsSource.SortDescriptions.Add(new SortDescription("Selection.StartLine", ListSortDirection.Ascending));
+            SearchResultsSource.SortDescriptions.Add(new SortDescription("Selection.StartColumn", ListSortDirection.Ascending));
+
+            SearchResults = new ObservableCollection<SearchResultItem>(searchResults);
+
             _closeCommand = new DelegateCommand(ExecuteCloseCommand);
         }
 
-        private readonly ObservableCollection<SearchResultItem> _searchResults;
-        public ObservableCollection<SearchResultItem> SearchResults { get { return _searchResults; } }
+        private ObservableCollection<SearchResultItem> _searchResults;
+        public ObservableCollection<SearchResultItem> SearchResults
+        {
+            get { return _searchResults; }
+            set
+            {
+                _searchResults = value;
 
-        private readonly CollectionViewSource _searchResultsSource;
-        public CollectionViewSource SearchResultsSource { get { return _searchResultsSource; } }
+                SearchResultsSource.Source = _searchResults;
+
+                OnPropertyChanged();
+                OnPropertyChanged("SearchResultsSource");
+            }
+        }
+
+        public CollectionViewSource SearchResultsSource { get; private set; }
 
         public string Header { get { return _header; } }
 
         private readonly ICommand _closeCommand;
         public ICommand CloseCommand { get { return _closeCommand; } }
 
-        public Declaration Target { get {return _target; } }
+        public Declaration Target { get; set; }
 
         private SearchResultItem _selectedItem;
         public SearchResultItem SelectedItem

--- a/RetailCoder.VBE/UI/Controls/SearchResultsWindowViewModel.cs
+++ b/RetailCoder.VBE/UI/Controls/SearchResultsWindowViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -21,10 +20,9 @@ namespace Rubberduck.UI.Controls
             RemoveTab(sender as SearchResultsViewModel);
         }
 
-        public IEnumerable<SearchResultsViewModel> Tabs { get { return _tabs; } }
+        public ObservableCollection<SearchResultsViewModel> Tabs { get { return _tabs; } }
 
         private SearchResultsViewModel _selectedTab;
-
         public SearchResultsViewModel SelectedTab
         {
             get { return _selectedTab; }

--- a/Rubberduck.Parsing/VBA/RubberduckParser.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParser.cs
@@ -62,12 +62,6 @@ namespace Rubberduck.Parsing.VBA
         private void StateOnStateChanged(object sender, EventArgs e)
         {
             Logger.Debug("RubberduckParser handles OnStateChanged ({0})", _state.Status);
-
-            /*if (_state.Status == ParserState.Parsed)
-            {
-                _logger.Debug("(handling OnStateChanged) Starting resolver task");
-                Resolve(_central.Token); // Tests expect this to be synchronous
-            }*/
         }
 
         private void ReparseRequested(object sender, ParseRequestEventArgs e)
@@ -83,10 +77,13 @@ namespace Rubberduck.Parsing.VBA
                 ParseAsync(e.Component, CancellationToken.None).Wait();
                 
                 Logger.Trace("Starting resolver task");
-                Resolve(_central.Token); // Tests expect this to be synchronous
+                Task.Run(() => Resolve(_central.Token));
             }
         }
 
+        /// <summary>
+        /// For the use of tests only
+        /// </summary>
         public void Parse()
         {
             if (!_state.Projects.Any())
@@ -112,12 +109,6 @@ namespace Rubberduck.Parsing.VBA
             {
                 _componentAttributes.Remove(invalidated);
             }
-
-            /*foreach (var vbComponent in components)
-            {
-                _state.ClearStateCache(vbComponent);
-                ParseComponent(vbComponent);
-            }*/
 
             var parseTasks = components.Select(vbComponent => ParseAsync(vbComponent, CancellationToken.None)).ToArray();
             Task.WaitAll(parseTasks);
@@ -180,7 +171,7 @@ namespace Rubberduck.Parsing.VBA
             Task.WaitAll(parseTasks);
             
             Logger.Trace("Starting resolver task");
-            Resolve(_central.Token); // Tests expect this to be synchronous
+            Task.Run(() => Resolve(_central.Token));
         }
 
         private void AddBuiltInDeclarations(IReadOnlyList<VBProject> projects)


### PR DESCRIPTION
* Refresh parser errors view on state changed.

* Tweak the implementation

* Update all search tab results on parse.  No more clunky adding/removing tabs.

* Remove dead code and make resolver run on non-UI thread.

* Close #1334