### PR TITLE
Add initial support for conditional deserialization\COM reflection.

### DIFF
--- a/RetailCoder.VBE/Root/RubberduckModule.cs
+++ b/RetailCoder.VBE/Root/RubberduckModule.cs
@@ -187,7 +187,7 @@ namespace Rubberduck.Root
                 .BindAllInterfaces()
                 .Configure(binding => binding.InSingletonScope()));
 
-            Bind<IPersistable<SerializableDeclarationTree>>().To<XmlPersistableDeclarations>().InCallScope();
+            Bind<IPersistable<SerializableProject>>().To<XmlPersistableDeclarations>().InCallScope();
 
             Bind<IPersistanceService<CodeInspectionSettings>>().To<XmlPersistanceService<CodeInspectionSettings>>().InCallScope();
             Bind<IPersistanceService<GeneralSettings>>().To<XmlPersistanceService<GeneralSettings>>().InCallScope();

--- a/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/SerializeDeclarationsCommandMenuItem.cs
+++ b/RetailCoder.VBE/UI/Command/MenuItems/CommandBars/SerializeDeclarationsCommandMenuItem.cs
@@ -20,9 +20,9 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
     public class SerializeDeclarationsCommand : CommandBase
     {
         private readonly RubberduckParserState _state;
-        private readonly IPersistable<SerializableDeclarationTree> _service;
+        private readonly IPersistable<SerializableProject> _service;
 
-        public SerializeDeclarationsCommand(RubberduckParserState state, IPersistable<SerializableDeclarationTree> service) 
+        public SerializeDeclarationsCommand(RubberduckParserState state, IPersistable<SerializableProject> service) 
             : base(LogManager.GetCurrentClassLogger())
         {
             _state = state;
@@ -39,14 +39,14 @@ namespace Rubberduck.UI.Command.MenuItems.CommandBars
 
         protected override void ExecuteImpl(object parameter)
         {
-            var path = Path.Combine(BasePath, "declarations");
+            var path = Path.Combine(BasePath, "Declarations");
             if (!Directory.Exists(path)) { Directory.CreateDirectory(path); }
 
             foreach (var tree in _state.BuiltInDeclarationTrees)
             {
                 System.Diagnostics.Debug.Assert(path != null, "project path isn't supposed to be null");
 
-                var filename = Path.GetFileNameWithoutExtension(tree.Node.QualifiedMemberName.QualifiedModuleName.ProjectName) + ".xml";
+                var filename = string.Format("{0}.{1}.{2}", tree.Node.QualifiedMemberName.QualifiedModuleName.ProjectName, tree.MajorVersion, tree.MinorVersion) + ".xml";
                 _service.Persist(Path.Combine(path, filename), tree);
             }
         }

--- a/Rubberduck.Parsing/Symbols/ComInformation.cs
+++ b/Rubberduck.Parsing/Symbols/ComInformation.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Runtime.InteropServices.ComTypes;
+﻿using System.Runtime.InteropServices.ComTypes;
 using Rubberduck.VBEditor;
 
 namespace Rubberduck.Parsing.Symbols

--- a/Rubberduck.Parsing/Symbols/ProjectDeclaration.cs
+++ b/Rubberduck.Parsing/Symbols/ProjectDeclaration.cs
@@ -31,6 +31,9 @@ namespace Rubberduck.Parsing.Symbols
             _projectReferences = new List<ProjectReference>();
         }
 
+        public long MajorVersion { get; set; }
+        public long MinorVersion { get; set; }
+
         public IReadOnlyList<ProjectReference> ProjectReferences
         {
             get

--- a/Rubberduck.Parsing/Symbols/XmlPersistableDeclarations.cs
+++ b/Rubberduck.Parsing/Symbols/XmlPersistableDeclarations.cs
@@ -7,9 +7,9 @@ using Rubberduck.SettingsProvider;
 
 namespace Rubberduck.Parsing.Symbols
 {
-    public class XmlPersistableDeclarations : IPersistable<SerializableDeclarationTree>
+    public class XmlPersistableDeclarations : IPersistable<SerializableProject>
     {
-        public void Persist(string path, SerializableDeclarationTree tree)
+        public void Persist(string path, SerializableProject tree)
         {
             if (string.IsNullOrEmpty(path)) { throw new InvalidOperationException(); }
 
@@ -26,20 +26,20 @@ namespace Rubberduck.Parsing.Symbols
             {
                 writer.WriteStartDocument();
                 var settings = new DataContractSerializerSettings {RootNamespace = XmlDictionaryString.Empty};
-                var serializer = new DataContractSerializer(typeof (SerializableDeclarationTree), settings);
+                var serializer = new DataContractSerializer(typeof(SerializableProject), settings);
                 serializer.WriteObject(writer, tree);
             }
         }
 
-        public SerializableDeclarationTree Load(string path)
+        public SerializableProject Load(string path)
         {
             if (string.IsNullOrEmpty(path)) { throw new InvalidOperationException(); }
             using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read))
             using (var xmlReader = XmlReader.Create(stream))
             using (var reader = XmlDictionaryReader.CreateDictionaryReader(xmlReader))
             {
-                var serializer = new DataContractSerializer(typeof(SerializableDeclarationTree));
-                return (SerializableDeclarationTree)serializer.ReadObject(reader);
+                var serializer = new DataContractSerializer(typeof(SerializableProject));
+                return (SerializableProject)serializer.ReadObject(reader);
             }
         }
     }

--- a/Rubberduck.Parsing/VBA/RubberduckParserState.cs
+++ b/Rubberduck.Parsing/VBA/RubberduckParserState.cs
@@ -586,8 +586,8 @@ namespace Rubberduck.Parsing.VBA
             }
         }
 
-        private readonly ConcurrentBag<SerializableDeclarationTree> _builtInDeclarationTrees = new ConcurrentBag<SerializableDeclarationTree>();
-        public IProducerConsumerCollection<SerializableDeclarationTree> BuiltInDeclarationTrees { get { return _builtInDeclarationTrees; } }
+        private readonly ConcurrentBag<SerializableProject> _builtInDeclarationTrees = new ConcurrentBag<SerializableProject>();
+        public IProducerConsumerCollection<SerializableProject> BuiltInDeclarationTrees { get { return _builtInDeclarationTrees; } }
 
         /// <summary>
         /// Gets a copy of the collected declarations, excluding the built-in ones.


### PR DESCRIPTION
Not getting any resolver errors with this on my test machine, although it could probably use testing in another environment.  The `ReferencedDeclarationsCollector` tests to see if a matching file-spec for a referenced tlb exists and deserializes that if it finds it.  If not, it processes the loaded tlb.